### PR TITLE
Bug fix: monitor string must be val_accuracy

### DIFF
--- a/INCV_main.py
+++ b/INCV_main.py
@@ -158,7 +158,7 @@ for iter in range(1,INCV_iter+1):
                                                   batch_size = batch_size),
                                   epochs = INCV_epochs,
                                   validation_data=(x_train[val1_idx,:], y_train_noisy[val1_idx,:]),
-                                  callbacks=[ModelCheckpoint(filepath=filepath_INCV, monitor='val_acc', verbose=1, save_best_only=INCV_save_best),
+                                  callbacks=[ModelCheckpoint(filepath=filepath_INCV, monitor='val_accuracy', verbose=1, save_best_only=INCV_save_best),
                                              noisy_acc,
                                              INCV_lr_callback])
     # Select samples of 'True' prediction

--- a/INCV_main.py
+++ b/INCV_main.py
@@ -117,7 +117,7 @@ for iter in range(1,INCV_iter+1):
                                                   batch_size = batch_size),
                                   epochs = INCV_epochs,
                                   validation_data=(x_train[val2_idx,:], y_train_noisy[val2_idx,:]),
-                                  callbacks=[ModelCheckpoint(filepath=filepath_INCV, monitor='val_acc', verbose=1, save_best_only=INCV_save_best),
+                                  callbacks=[ModelCheckpoint(filepath=filepath_INCV, monitor='val_accuracy', verbose=1, save_best_only=INCV_save_best),
                                              noisy_acc,
                                              INCV_lr_callback])
     # Select samples of 'True' prediction


### PR DESCRIPTION
Without this fix, the model will not save, and the code will fail after the first pass of INCV when it tries to load a model that was not saved due to callback failure. This is a standard fix (see: https://github.com/tensorflow/tensorflow/issues/33163).